### PR TITLE
Update 2.4.1-alpine3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-FROM ruby:2.4.1-alpine
-
-#  Ruby
-#-----------------------------------------------
-ENV BUNDLER_VERSION 1.14.4
-
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-# Ignore warning: "Don't run Bundler as root."
-# @see https://github.com/docker-library/rails/issues/10
-  && bundle config --global silence_root_warning 1 \
-# Ignore insecure `git` protocol for gem
-  && bundle config --global git.allow_insecure true
+FROM ruby:2.4.1-alpine3.6
 
 # Disable spring for good
 ENV DISABLE_SPRING 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.1-alpine3.6
+FROM ruby:2.4.1-alpine3.4
 
 # Disable spring for good
 ENV DISABLE_SPRING 1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,4 +202,4 @@ DEPENDENCIES
   webpacker
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/script/ci-deploy
+++ b/script/ci-deploy
@@ -5,4 +5,4 @@ set -o pipefail
 
 cd "$(dirname $0)/.."
 echo "Deploy ${REPO}:${TAG_COMMIT} to production"
-# ./kubectl set image deployment/${DEPLOYMENT_NAME} ${DEPLOYMENT_NAME}=${REPO}:${TAG_COMMIT} --namespace=${NAMESPACE}
+# ./kubectl set image deployment/${DEPLOYMENT_NAME} rails=${REPO}:${TAG_COMMIT} --namespace=${NAMESPACE}


### PR DESCRIPTION
## WHY

fix

```
bundler: failed to load command: puma (/app/vendor/bundle/ruby/2.4.0/bin/puma)
LoadError: Error relocating /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/puma_http11.so: __memcpy_chk: symbol not found - /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/puma_http11.so
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/server.rb:15:in `require'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/server.rb:15:in `<top (required)>'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/runner.rb:1:in `require'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/runner.rb:1:in `<top (required)>'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:1:in `require'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/cluster.rb:1:in `<top (required)>'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/launcher.rb:4:in `require'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/launcher.rb:4:in `<top (required)>'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/cli.rb:5:in `require'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/lib/puma/cli.rb:5:in `<top (required)>'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/bin/puma:6:in `require'
  /app/vendor/bundle/ruby/2.4.0/gems/puma-3.10.0/bin/puma:6:in `<top (required)>'
  /app/vendor/bundle/ruby/2.4.0/bin/puma:23:in `load'
  /app/vendor/bundle/ruby/2.4.0/bin/puma:23:in `<top (required)>'
```


