### PR TITLE
Fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ README.md
 .rspec
 log
 tmp
+vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.4.1-alpine
 
 #  Ruby
 #-----------------------------------------------
-ENV BUNDLER_VERSION 1.14.4
+ENV BUNDLER_VERSION 1.14.6
 
 RUN gem install bundler --version "$BUNDLER_VERSION" \
 # Ignore warning: "Don't run Bundler as root."

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,4 +202,4 @@ DEPENDENCIES
   webpacker
 
 BUNDLED WITH
-   1.15.4
+   1.14.6


### PR DESCRIPTION
## WHY

```
$ docker run -e RAILS_ENV=production -e DATABASE_URL=postgres://postgres/myapp  quay.io/koudaiii/myapp:241b6ac
/app/vendor/bundle/ruby/2.4.0/gems/pg-0.21.0/lib/pg.rb:4:in `require': Error relocating /app/vendor/bundle/ruby/2.4.0/gems/pg-0.21.0/lib/pg_ext.so: __isnan: symbol not found - /app/vendor/bundle/ruby/2.4.0/gems/pg-0.21.0/lib/pg_ext.so (LoadError)
	from /app/vendor/bundle/ruby/2.4.0/gems/pg-0.21.0/lib/pg.rb:4:in `<top (required)>'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:82:in `require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:82:in `block (2 levels) in require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:77:in `each'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:77:in `block in require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:66:in `each'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/runtime.rb:66:in `require'
	from /usr/local/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler.rb:108:in `require'
	from /app/config/application.rb:7:in `<top (required)>'
	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.3/lib/rails/commands/server/server_command.rb:129:in `require'
	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.3/lib/rails/commands/server/server_command.rb:129:in `block in perform'
	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.3/lib/rails/commands/server/server_command.rb:126:in `tap'
	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.3/lib/rails/commands/server/server_command.rb:126:in `perform'
	from /app/vendor/bundle/ruby/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /app/vendor/bundle/ruby/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /app/vendor/bundle/ruby/2.4.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.3/lib/rails/command/base.rb:63:in `perform'
	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.3/lib/rails/command.rb:44:in `invoke'
	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.3/lib/rails/commands.rb:16:in `<top (required)>'
	from bin/rails:9:in `require'
	from bin/rails:9:in `<main>'
```

- latest tag is build in local pc
- 241b6ac tag is build in travis-ci

```
$ docker images
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
quay.io/koudaiii/myapp           latest              5f17bb9b5e48        21 minutes ago      208MB
quay.io/koudaiii/myapp           241b6ac             2387bb4f82b7        36 minutes ago      301MB
```

## WHAT

Do not need vendor for docker build. ignored!