### PR TITLE
Fix HorizontalPodAutoscaler

### DIFF
--- a/kubernetes/myapp.yaml
+++ b/kubernetes/myapp.yaml
@@ -77,6 +77,10 @@ spec:
             exec:
             # SIGTERM triggers a quick exit; gracefully terminate instead
               command: ["/usr/sbin/nginx","-s","quit"]
+        resources:
+          limits:
+            memory: "256Mi"
+            cpu: "256m"
         volumeMounts:
           - mountPath: /app/public
             name: public


### PR DESCRIPTION
## WHY

Fix HorizontalPodAutoscaler

```
myapp                               2018-02-06 20:52:42 +0900 JST   2018-02-06 20:51:42 +0900 JST   3         myapp.1510ba4a462ab061                                                                      HorizontalPodAutoscaler                                              Warning   FailedGetResourceMetric        horizontal-pod-autoscaler                                      unable to get metrics for resource cpu: no metrics returned from heapster
myapp                               2018-02-06 20:52:42 +0900 JST   2018-02-06 20:51:42 +0900 JST   3         myapp.1510ba4a46b23d82                                                                      HorizontalPodAutoscaler                                              Warning   FailedComputeMetricsReplicas   horizontal-pod-autoscaler                                      failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from heapster
myapp                               2018-02-06 20:54:12 +0900 JST   2018-02-06 20:53:12 +0900 JST   3         myapp.1510ba5f3ce97a01                                                                      HorizontalPodAutoscaler                                              Warning   FailedGetResourceMetric        horizontal-pod-autoscaler                                      missing request for cpu on container nginx in pod myapp/myapp-1447410097-dq6gg
myapp                               2018-02-06 20:54:12 +0900 JST   2018-02-06 20:53:12 +0900 JST   3         myapp.1510ba5f3d67c5e6                                                                      HorizontalPodAutoscaler                                              Warning   FailedComputeMetricsReplicas   horizontal-pod-autoscaler                                      failed to get cpu utilization: missing request for cpu on container nginx in pod myapp/myapp-1447410097-dq6gg
```

## WHAT

Add resources in nginx container